### PR TITLE
ci: bypass branch protection on automatic updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,7 +16,7 @@ jobs:
       -
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.REPO_GHA_PAT }}
           fetch-depth: 0
       -
         name: Get latest PgBouncer
@@ -85,6 +85,15 @@ jobs:
           fi
           echo TAG=${{ env.PGBOUNCER_VERSION }}-${release_number} >> $GITHUB_ENV
       -
+        name: Temporarily disable "include administrators" branch protection
+        if: always()
+        id: disable_include_admins
+        uses: benjefferies/branch-protection-bot@1.0.7
+        with:
+          access_token: ${{ secrets.REPO_GHA_PAT }}
+          branch: ${{ github.event.repository.default_branch }}
+          enforce_admins: false
+      -
         name: Commit changes
         if: ${{ github.ref == 'refs/heads/main' && env.UPDATED == 'true' }}
         uses: EndBug/add-and-commit@v7
@@ -94,3 +103,11 @@ jobs:
           author_email: noreply@enterprisedb.com
           message: 'Automatic update'
           tag: v${{ env.TAG }}
+      -
+        name: Enable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@1.0.7
+        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+        with:
+          access_token: ${{ secrets.REPO_GHA_PAT }}
+          branch: ${{ github.event.repository.default_branch }}
+          enforce_admins: ${{ steps.disable_include_admins.outputs.initial_status }}


### PR DESCRIPTION
Allow the update job to push changes on the main branch even if protected